### PR TITLE
Fix ineffective rate limiting implementation using usleep() - Replace…

### DIFF
--- a/app/Http/Controllers/SecretController.php
+++ b/app/Http/Controllers/SecretController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Secret;
 use App\Services\SecretNotFoundException;
 use App\Services\SecretService;
+use App\Services\TooManyAttemptsException;
 use Throwable;
 
 class SecretController extends Controller
@@ -89,6 +90,8 @@ class SecretController extends Controller
             );
         } catch (SecretNotFoundException $th) {
             return response()->json(['error' => 'Not Found'], 404);
+        } catch (TooManyAttemptsException $th) {
+            return response()->json(['error' => 'Too Many Attempts'], 429);
         } catch (Throwable $th) {
             return response()->json(['error' => 'Unauthorized'], 401);
         }

--- a/config/app.php
+++ b/config/app.php
@@ -126,4 +126,8 @@ return [
     'secrets_lifetime' => env('SECRETS_LIFETIME_IN_MINUTES', 60),
     'crypt_iterations' => env('CRYPT_ITERATIONS', 100000),
     'enable_secret_rate_limiting' => env('ENABLE_SECRET_RATE_LIMITING', true),
+    'secret_rate_limit_attempts' => env('SECRET_RATE_LIMIT_ATTEMPTS', 5),
+    'secret_rate_limit_decay' => env('SECRET_RATE_LIMIT_DECAY', 3600), // 1 hour
+    'ip_rate_limit_attempts' => env('IP_RATE_LIMIT_ATTEMPTS', 20),
+    'ip_rate_limit_decay' => env('IP_RATE_LIMIT_DECAY', 3600), // 1 hour
 ];


### PR DESCRIPTION
… usleep() with proper Laravel RateLimiter - Add per-secret rate limiting (5 attempts per secret) - Add per-IP rate limiting (20 attempts per hour) - Add configurable rate limiting settings - Add TooManyAttemptsException for proper error handling - Update controller to return 429 status for rate limit exceeded - Add comprehensive tests for new rate limiting functionality - Remove blocking usleep() that affected performance - Fixes GLO-10